### PR TITLE
Hotfix removal of router

### DIFF
--- a/app.js
+++ b/app.js
@@ -32,7 +32,7 @@ app.use(session({
 }));
 app.use(passport.initialize());
 app.use(passport.session());
-//app.use(app.router);
+// app.use(app.router);
 app.use(express.static(path.join(__dirname, 'public')));
 
 // env config
@@ -53,6 +53,9 @@ passport.deserializeUser(Account.deserializeUser());
 // mongoose
 var database = require('./config/db');
 mongoose.connect(database.url);
+
+// routes
+require('./router')(app);
 
 app.listen(app.get('port'), function(){
   console.log(('Express server listening on port ' + app.get('port')));

--- a/config/db.js
+++ b/config/db.js
@@ -1,3 +1,3 @@
 module.exports = {
-  'url' : 'mongodb://localhost/weirdtube'
+  'url' : 'mongodb://127.0.0.1/weirdtube'
 };


### PR DESCRIPTION
@Jacob-Lane mentioned this before. When I was prettifying the code, I accidentally removed the router from `app.js`. The result of this was that any page would just error and say "Couldn't GET [path]". The server still doesn't work, but that's just the `BannedVideo` stuff.

I also updated the DB config to work without a network connection; localhost wasn't resolving on my machine so I put in 127.0.0.1 instead.